### PR TITLE
Code Along: Reviews

### DIFF
--- a/Ruby/reviews/Gemfile
+++ b/Ruby/reviews/Gemfile
@@ -1,0 +1,1 @@
+source 'https://rubygems.org'

--- a/Ruby/reviews/Gemfile.lock
+++ b/Ruby/reviews/Gemfile.lock
@@ -1,0 +1,11 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+
+BUNDLED WITH
+   2.1.4

--- a/Ruby/reviews/dev.yml
+++ b/Ruby/reviews/dev.yml
@@ -1,0 +1,20 @@
+name: reviews
+
+type: ruby
+
+up:
+  - ruby: 2.7.1
+  - bundler
+
+commands:
+  console:
+    desc:   'start a console'
+    run:    bin/console
+  run:
+    desc:   'start the application'
+    run:    bin/run
+  test:
+    syntax:
+      argument: file
+      optional: args...
+    run: bin/testunit

--- a/Ruby/reviews/reviews.rb
+++ b/Ruby/reviews/reviews.rb
@@ -1,0 +1,7 @@
+lines = []
+
+File.open("reviews.txt") do |review_file|
+  lines = review_file.readlines
+end
+
+puts lines.length

--- a/Ruby/reviews/reviews.rb
+++ b/Ruby/reviews/reviews.rb
@@ -5,3 +5,13 @@ File.open("reviews.txt") do |review_file|
 end
 
 puts lines.length
+
+relevant_lines = []
+
+lines.each do |line|
+  if line.include?("Truncated")
+    relevant_lines << line
+  end
+end
+
+puts relevant_lines

--- a/Ruby/reviews/reviews.rb
+++ b/Ruby/reviews/reviews.rb
@@ -8,4 +8,6 @@ puts lines.length
 
 relevant_lines = lines.find_all { |line| line.include? ("Truncated") }
 
-puts relevant_lines
+reviews = relevant_lines.reject { |line| line.include?("--") }
+
+puts reviews

--- a/Ruby/reviews/reviews.rb
+++ b/Ruby/reviews/reviews.rb
@@ -1,23 +1,21 @@
-lines = []
+def find_adjective(string)
+  words = string.split(" ")
+  index = words.find_index("is")
+  words[index + 1].delete(":")
+end
 
+lines = []
 File.open("reviews.txt") do |review_file|
   lines = review_file.readlines
 end
 
 relevant_lines = lines.find_all { |line| line.include? ("Truncated") }
-
 reviews = relevant_lines.reject { |line| line.include?("--") }
 
-def find_adjective(string)
-  words = string.split(" ")
-  index = words.find_index("is")
-  words[index + 1]
+adjectives = reviews.map do |review|
+  adjective = find_adjective(review)
+  "'#{adjective.capitalize}'"
 end
 
-adjectives = []
-
-reviews.each do |review|
-  adjectives << find_adjective(review)
-end
-
+puts "The critics agree, Truncates is:"
 puts adjectives

--- a/Ruby/reviews/reviews.rb
+++ b/Ruby/reviews/reviews.rb
@@ -4,10 +4,20 @@ File.open("reviews.txt") do |review_file|
   lines = review_file.readlines
 end
 
-puts lines.length
-
 relevant_lines = lines.find_all { |line| line.include? ("Truncated") }
 
 reviews = relevant_lines.reject { |line| line.include?("--") }
 
-puts reviews
+def find_adjective(string)
+  words = string.split(" ")
+  index = words.find_index("is")
+  words[index + 1]
+end
+
+adjectives = []
+
+reviews.each do |review|
+  adjectives << find_adjective(review)
+end
+
+puts adjectives

--- a/Ruby/reviews/reviews.rb
+++ b/Ruby/reviews/reviews.rb
@@ -6,12 +6,6 @@ end
 
 puts lines.length
 
-relevant_lines = []
-
-lines.each do |line|
-  if line.include?("Truncated")
-    relevant_lines << line
-  end
-end
+relevant_lines = lines.find_all { |line| line.include? ("Truncated") }
 
 puts relevant_lines

--- a/Ruby/reviews/reviews.txt
+++ b/Ruby/reviews/reviews.txt
@@ -1,0 +1,8 @@
+Normally producers and directors would stop this kind of garbage from getting published. Truncated is amazing in that it got past those hurdles.
+--Joseph Goldstein, "Truncated: Awful," New York Minute
+Guppies is destined to be the family film favorite of the summer.
+--Bill Mosher, "Go see Guppies," Topeka Obscurant
+Truncated is funny: it can't be categorized as comedy, romance, or horror, because none of those genres would want to be associated with it.
+--Liz Smith, "Truncated Disappoints," Chicago Some-Times
+I'm pretty sure this was shot on a mobile phone. Truncated is astounding in its disregard for filmmaking aesthetics.
+--Bill Mosher, "Don't See Truncated," Topeka Obscurant


### PR DESCRIPTION
### Outline

This PR works through the Reviews Code Along from Week 3 of DEV2020-Zoom.

I made a small adjustment on line 4 to remove the `:` rather than changing how it appeared in the `reviews.txt` file. 

### Examples

![](http://screenshot.click/20-13-j8ffg-dq3f5.png)